### PR TITLE
Add `as_command_choices` function

### DIFF
--- a/toolbox/utils.py
+++ b/toolbox/utils.py
@@ -435,7 +435,7 @@ def as_command_choices(*args: t.Any, **kwargs: t.Any) -> t.Sequence[hikari.Comma
     if len(args) != 1:
         return _list_to_command_choices(args)
 
-    choices = args[0]
+    (choices,) = args
 
     if isinstance(choices, dict):
         return _dict_to_command_choices(choices)

--- a/toolbox/utils.py
+++ b/toolbox/utils.py
@@ -386,33 +386,40 @@ def as_command_choices(**kwargs: ChoiceTypes) -> t.Sequence[hikari.CommandChoice
 
 
 def as_command_choices(*args: t.Any, **kwargs: t.Any) -> t.Sequence[hikari.CommandChoice]:
-    """
-    Conver the arguments to `typing.Sequence[hikari.CommandChoice]`.
+    """Convert the arguments to `typing.Sequence[hikari.CommandChoice]`.
 
     Parameters
     ----------
-    *args : typing.Union[str, int, float] or typing.Sequence[typing.Union[str, int, float]] or dict[str, typing.Union[str, int, float]], optional
-        The parameters to make the `typing.Sequence[CommandChoice]` with with.
-
-        *args can be provided in any of the following ways:
+    choices : typing.Sequence[typing.Union[str, int, float]] or typing.Sequence[typing.Sequence[typing.Union[str, int, float]]] or dict[str, typing.Union[str, int, float]]
+        A sequence or dict to use to generate the `typing.Sequence[hikari.CommandChoice]`.
 
         .. code-block:: python
+
             # Returns `(CommandChoice(name='a', value='a'), CommandChoice(name='b', value='b'), CommandChoice(name='c', value='c'))`
             toolbox.as_command_choices(["a", "b", "c"])
 
+            # Returns `(CommandChoice(name='a', value='e'), CommandChoice(name='b', value='f'), CommandChoice(name='c', value='g'))`
+            toolbox.as_command_choices({"a": "e", "b": "f", "c": "g"})
+            toolbox.as_command_choices([["a", "d"], ["b", "e"], ["c", "f"]])
+
+    *args : typing.Union[str, int, float] or typing.Sequence[typing.Union[str, int, float]], optional
+        The parameters to make the `typing.Sequence[CommandChoice]` with with.
+
+        \*args can be provided in any of the following ways:
+
+        .. code-block:: python
+
+            # Returns `(CommandChoice(name='a', value='a'), CommandChoice(name='b', value='b'), CommandChoice(name='c', value='c'))`
             toolbox.as_command_choices("a", "b", "c")
 
             # Returns `(CommandChoice(name='a', value='e'), CommandChoice(name='b', value='f'), CommandChoice(name='c', value='g'))`
-            toolbox.as_command_choices([["a", "d"], ["b", "e"], ["c", "f"]])
-
-            toolbox.as_command_choices({"a": "e", "b": "f", "c": "g"})
-
             toolbox.as_command_choices(["a", "e"], ["b", "f"], ["c", "g"])
 
     **kwargs : str, optional
         If provided, use kwargs as the (name, value) for each `hikari.Commandchoice`.
 
         .. code-block:: python
+
             # Returns `(CommandChoice(name='a', value='e'), CommandChoice(name='b', value='f'), CommandChoice(name='c', value='g'))`
             toolbox.as_command_choices(a="e", b="f", c="g")
 

--- a/toolbox/utils.py
+++ b/toolbox/utils.py
@@ -389,22 +389,37 @@ def as_command_choices(*args: t.Any, **kwargs: t.Any) -> t.Sequence[hikari.Comma
     """
     Conver the arguments to `typing.Sequence[hikari.CommandChoice]`.
 
-    The following inputs return
-    `(CommandChoice(name='a', value='a'), CommandChoice(name='b', value='b'), CommandChoice(name='c', value='c'))`
+    Parameters
+    ----------
+    *args : typing.Union[str, int, float] or typing.Sequence[typing.Union[str, int, float]] or dict[str, typing.Union[str, int, float]], optional
+        The parameters to make the `typing.Sequence[CommandChoice]` with with.
 
-    .. code-block:: python
+        *args can be provided in any of the following ways:
 
-        toolbox.as_command_choices(["a", "b", "c"])
+        .. code-block:: python
+            # Returns `(CommandChoice(name='a', value='a'), CommandChoice(name='b', value='b'), CommandChoice(name='c', value='c'))`
+            toolbox.as_command_choices(["a", "b", "c"])
 
-        toolbox.as_command_choices([["a", "d"], ["b", "e"], ["c", "f"]])
+            toolbox.as_command_choices("a", "b", "c")
 
-        toolbox.as_command_choices({"a": "e", "b": "f", "c": "g"})
+            # Returns `(CommandChoice(name='a', value='e'), CommandChoice(name='b', value='f'), CommandChoice(name='c', value='g'))`
+            toolbox.as_command_choices([["a", "d"], ["b", "e"], ["c", "f"]])
 
-        toolbox.as_command_choices("a", "b", "c")
+            toolbox.as_command_choices({"a": "e", "b": "f", "c": "g"})
 
-        toolbox.as_command_choices(["a", "e"], ["b", "f"], ["c", "g"])
+            toolbox.as_command_choices(["a", "e"], ["b", "f"], ["c", "g"])
 
-        toolbox.as_command_choices(a="e", b="f", c="g")
+    **kwargs : str, optional
+        If provided, use kwargs as the (name, value) for each `hikari.Commandchoice`.
+
+        .. code-block:: python
+            # Returns `(CommandChoice(name='a', value='e'), CommandChoice(name='b', value='f'), CommandChoice(name='c', value='g'))`
+            toolbox.as_command_choices(a="e", b="f", c="g")
+
+    Returns
+    -------
+    typing.Sequence[hikari.CommandChoice]
+        The generated `hikari.CommandChoice` objects.
 
     """
     if len(args) != 1:

--- a/toolbox/utils.py
+++ b/toolbox/utils.py
@@ -386,6 +386,27 @@ def as_command_choices(**kwargs: ChoiceTypes) -> t.Sequence[hikari.CommandChoice
 
 
 def as_command_choices(*args: t.Any, **kwargs: t.Any) -> t.Sequence[hikari.CommandChoice]:
+    """
+    Conver the arguments to `typing.Sequence[hikari.CommandChoice]`.
+
+    The following inputs return
+    `(CommandChoice(name='a', value='a'), CommandChoice(name='b', value='b'), CommandChoice(name='c', value='c'))`
+
+    .. code-block:: python
+
+        toolbox.as_command_choices(["a", "b", "c"])
+
+        toolbox.as_command_choices([["a", "d"], ["b", "e"], ["c", "f"]])
+
+        toolbox.as_command_choices({"a": "e", "b": "f", "c": "g"})
+
+        toolbox.as_command_choices("a", "b", "c")
+
+        toolbox.as_command_choices(["a", "e"], ["b", "f"], ["c", "g"])
+
+        toolbox.as_command_choices(a="e", b="f", c="g")
+
+    """
     if len(args) != 1:
         if kwargs:
             return _dict_to_command_choices(kwargs)

--- a/toolbox/utils.py
+++ b/toolbox/utils.py
@@ -429,9 +429,10 @@ def as_command_choices(*args: t.Any, **kwargs: t.Any) -> t.Sequence[hikari.Comma
         The generated `hikari.CommandChoice` objects.
 
     """
+    if kwargs:
+        return _dict_to_command_choices(kwargs)
+
     if len(args) != 1:
-        if kwargs:
-            return _dict_to_command_choices(kwargs)
         return _list_to_command_choices(args)
 
     choices = args[0]


### PR DESCRIPTION
New ways to create `typing.Sequence[CommandChoices]`.

```python
import toolbox


toolbox.as_command_choices(["a", "b", "c"])

toolbox.as_command_choices([["a", "d"], ["b", "e"], ["c", "f"]])

toolbox.as_command_choices({"a": "e", "b": "f", "c": "g"})

toolbox.as_command_choices("a", "b", "c")

toolbox.as_command_choices(["a", "e"], ["b", "f"], ["c", "g"])

toolbox.as_command_choices(a="e", b="f", c="g")
```