### PR TITLE
Add pytest async handler

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -42,6 +42,7 @@ def pytest(session: nox.Session):
     session.install("-Ur", "requirements.txt")
     session.install("-U", ".")
     session.install("-U", "pytest")
+    session.install("-U", "pytest-asyncio")
     session.run("pytest", PATH_TO_TESTS)
 
 

--- a/toolbox/utils.py
+++ b/toolbox/utils.py
@@ -427,7 +427,7 @@ def as_command_choices(*args: t.Any, **kwargs: t.Any) -> t.Sequence[hikari.Comma
     *args : typing.Union[str, int, float] or typing.Sequence[typing.Union[str, int, float]], optional
         The parameters to make the `typing.Sequence[CommandChoice]` with with.
 
-        \*args can be provided in any of the following ways:
+        *args can be provided in any of the following ways:
 
         .. code-block:: python
 


### PR DESCRIPTION
Fix pytest warnings for missing asyncio handler (and a faulty docstring).